### PR TITLE
Removed redundant code in AnimSpriteRenderer.

### DIFF
--- a/Duality/Components/Renderers/AnimSpriteRenderer.cs
+++ b/Duality/Components/Renderers/AnimSpriteRenderer.cs
@@ -460,8 +460,6 @@ namespace Duality.Components.Renderers
 				else
 					uvRectNext = uvRect;
 			}
-			else if (mainTex != null)
-				uvRect = uvRectNext = new Rect(mainTex.UVRatio.X, mainTex.UVRatio.Y);
 			else
 				uvRect = uvRectNext = new Rect(1.0f, 1.0f);
 		}


### PR DESCRIPTION
In light of this issue here:
https://github.com/AdamsLair/duality/issues/253

The removed code would not be executed, and as such was deemed to be harmless to remove in the above mentioned issue.